### PR TITLE
Update scripts for compatibility with Frida 17.x

### DIFF
--- a/scripts/IOKit.js
+++ b/scripts/IOKit.js
@@ -25,10 +25,11 @@ var tree = Memory.alloc(16);
 var treeCount = Memory.alloc(16);
 
 // step 1: get addresses for kernel functions
-var addr_mach_task_self = Module.getExportByName('libsystem_kernel.dylib', 'mach_task_self');
-var addr_mach_port_space_info = Module.getExportByName('libsystem_kernel.dylib', 'mach_port_space_info');
-var addr_mach_port_kobject = Module.getExportByName('libsystem_kernel.dylib', 'mach_port_kobject');
-var addr_mach_port_kobject_description = Module.getExportByName('libsystem_kernel.dylib', 'mach_port_kobject_description');
+const libsystem_kernel = Process.getModuleByName('libsystem_kernel.dylib');
+var addr_mach_task_self = libsystem_kernel.getExportByName('mach_task_self');
+var addr_mach_port_space_info = libsystem_kernel.getExportByName('mach_port_space_info');
+var addr_mach_port_kobject = libsystem_kernel.getExportByName('mach_port_kobject');
+var addr_mach_port_kobject_description = libsystem_kernel.getExportByName('mach_port_kobject_description');
 
 // step 2: create NativeFunctions
 var mach_task_self = new NativeFunction(addr_mach_task_self, 'int', []);
@@ -191,7 +192,7 @@ function hookIt(fn) {
     // console.log('\n');
 
     // Create frida hook
-    var addr = Module.getExportByName('IOKit', name);
+    var addr = Process.getModuleByName('IOKit').getExportByName(name);
     Interceptor.attach(addr, {
         onEnter: function(args) {
             log_call(name, args, arglist);

--- a/scripts/jetsamctl.js
+++ b/scripts/jetsamctl.js
@@ -2,7 +2,7 @@
 // e.g., dasd:
 //   `frida -U dasd -l jetsamctl.js`
 
-const memorystatus_control_addr = Module.getExportByName('libsystem_kernel.dylib', 'memorystatus_control');
+const memorystatus_control_addr = Process.getModuleByName('libsystem_kernel.dylib').getExportByName('memorystatus_control');
 const memorystatus_control = new NativeFunction(memorystatus_control_addr, 'int', ['int', 'int', 'int', 'pointer', 'int']);
 const MEMORYSTATUS_CMD_SET_JETSAM_TASK_LIMIT = 6;
 

--- a/scripts/libdispatch.js
+++ b/scripts/libdispatch.js
@@ -32,7 +32,8 @@ function print_block_invoke(dispatch_block) {
 }
 
 // Get name of a queue
-const _dispatch_queue_get_label_addr = Module.getExportByName('libdispatch.dylib', 'dispatch_queue_get_label');
+const libdispatch = Process.getModuleByName('libdispatch.dylib');
+const _dispatch_queue_get_label_addr = libdispatch.getExportByName('dispatch_queue_get_label');
 const _dispatch_queue_get_label = new NativeFunction(_dispatch_queue_get_label_addr, "pointer", ["pointer"]);
 function print_queue_label(dispatch_queue) {
     return `Calling queue: ${_dispatch_queue_get_label(dispatch_queue).readUtf8String()}\n`;
@@ -46,7 +47,7 @@ function print_backtrace(ctx) {
 
 // Hook async dispatching. We do the backtrace in the thread *before* dispatch_async
 // was called, so we're off by one.
-const _dispatch_async_addr = Module.getExportByName('libdispatch.dylib', 'dispatch_async');
+const _dispatch_async_addr = libdispatch.getExportByName('dispatch_async');
 Interceptor.attach(_dispatch_async_addr, {
     onEnter: function(args) {
         console.log('dispatch_async\n' +
@@ -57,7 +58,7 @@ Interceptor.attach(_dispatch_async_addr, {
 });
 
 // Dispatching sync. Used a lot during service creation.
-const _dispatch_sync_addr = Module.getExportByName('libdispatch.dylib', 'dispatch_sync');
+const _dispatch_sync_addr = libdispatch.getExportByName('dispatch_sync');
 Interceptor.attach(_dispatch_sync_addr, {
     onEnter: function(args) {
         console.log('dispatch_sync\n' +
@@ -68,7 +69,7 @@ Interceptor.attach(_dispatch_sync_addr, {
 });
 
 // Dispatch queue creation
-const _dispatch_queue_create_addr = Module.getExportByName('libdispatch.dylib', 'dispatch_queue_create');
+const _dispatch_queue_create_addr = libdispatch.getExportByName('dispatch_queue_create');
 Interceptor.attach(_dispatch_queue_create_addr, {
     onEnter: function(args) {
         console.log('dispatch_queue_create\n' +
@@ -78,7 +79,7 @@ Interceptor.attach(_dispatch_queue_create_addr, {
 });
 
 // Hook time dispatching, but this only gives time constraints so it shouldn't be relevant for us.
-const _dispatch_time_addr = Module.getExportByName('libdispatch.dylib', 'dispatch_time');
+const _dispatch_time_addr = libdispatch.getExportByName('dispatch_time');
 Interceptor.attach(_dispatch_time_addr, {
     onEnter: function(args) {
         console.log('dispatch_time\n');
@@ -86,7 +87,7 @@ Interceptor.attach(_dispatch_time_addr, {
 });
 
 // Delayed dispatching
-const _dispatch_after_addr = Module.getExportByName('libdispatch.dylib', 'dispatch_after');
+const _dispatch_after_addr = libdispatch.getExportByName('dispatch_after');
 Interceptor.attach(_dispatch_after_addr, {
     onEnter: function(args) {
         console.log('dispatch_after\n' +

--- a/scripts/mach_msg.js
+++ b/scripts/mach_msg.js
@@ -29,7 +29,7 @@ var mach_remove_xpc = false;
 
 
 
-var _mach_msg_addr = Module.getExportByName('libSystem.B.dylib', 'mach_msg');
+var _mach_msg_addr = Process.getModuleByName('libSystem.B.dylib').getExportByName('mach_msg');
 
 // Using some global variables here for onEnter vs. onLeave, works most of the time...
 var _mach_msg_body_ptr;

--- a/scripts/objc_msg.js
+++ b/scripts/objc_msg.js
@@ -3,7 +3,7 @@ Prints all Objective-C calls (without arguments).
 Huge performance impact, handle with care.
 */
 
-const _objc_msgSend = Module.getExportByName(null, 'objc_msgSend');
+const _objc_msgSend = Module.getGlobalExportByName('objc_msgSend');
 Interceptor.attach(_objc_msgSend, {
     onEnter: function(args) {
         console.log(`objc_msgSend(${(new ObjC.Object(args[0])).$className}, ${args[1].readCString()})`);

--- a/scripts/os_log.js
+++ b/scripts/os_log.js
@@ -1,5 +1,3 @@
-
-
 /*
     Function that prints OS Log args.
 
@@ -185,7 +183,8 @@ function printLog(args) {
 }
 
 // Fake that all log types are enabled
-const isEnabledFunc = Module.findExportByName('libsystem_trace.dylib', 'os_log_type_enabled');
+const libsystem_trace = Process.getModuleByName('libsystem_trace.dylib');
+const isEnabledFunc = libsystem_trace.getExportByName('os_log_type_enabled');
 Interceptor.attach(isEnabledFunc, {
   onLeave: function (ret) {
     ret.replace(1);
@@ -193,10 +192,10 @@ Interceptor.attach(isEnabledFunc, {
 });
 
 // Hook all log levels and print them in different colors
-const log_default = Module.findExportByName('libsystem_trace.dylib', '_os_log_impl')
-const log_fault = Module.findExportByName('libsystem_trace.dylib', '_os_log_fault_impl')
-const log_debug = Module.findExportByName('libsystem_trace.dylib', '_os_log_debug_impl')
-const log_error = Module.findExportByName('libsystem_trace.dylib', '_os_log_error_impl')
+const log_default = libsystem_trace.getExportByName('_os_log_impl')
+const log_fault = libsystem_trace.getExportByName('_os_log_fault_impl')
+const log_debug = libsystem_trace.getExportByName('_os_log_debug_impl')
+const log_error = libsystem_trace.getExportByName('_os_log_error_impl')
 
 Interceptor.attach(log_default, {
     onEnter: function (args) {

--- a/scripts/stalker.js
+++ b/scripts/stalker.js
@@ -1,6 +1,6 @@
 console.log("loading");
 
-const f = Module.getExportByName(null, 'open');
+const f = Module.getGlobalExportByName('open');
 
 Interceptor.attach(f, {
     onEnter: function(args) {


### PR DESCRIPTION
This pull request updates the existing scripts to ensure compatibility with Frida 17.x API.

###  Updated getModule and getExport API calls:

* Updated `scripts/IOKit.js` to use `Process.getModuleByName` for retrieving exports from `libsystem_kernel.dylib` and `IOKit`. This ensures module-specific exports are accessed in a more structured way. [[1]](diffhunk://#diff-67507cf58858e4eb5378d63bc23f39e039b067fd47e8bc69b6b341ac174977b4L28-R32) [[2]](diffhunk://#diff-67507cf58858e4eb5378d63bc23f39e039b067fd47e8bc69b6b341ac174977b4L194-R195)
* Updated `scripts/jetsamctl.js` to use `Process.getModuleByName` for retrieving the `memorystatus_control` export from `libsystem_kernel.dylib`.
* Updated `scripts/libdispatch.js` to use `Process.getModuleByName` for retrieving multiple exports from `libdispatch.dylib`, improving consistency across the script. [[1]](diffhunk://#diff-e3ed676ea26a4bbaef6080f871a0e82b0cea7af3401eb831d3ff12d0cf21623aL35-R36) [[2]](diffhunk://#diff-e3ed676ea26a4bbaef6080f871a0e82b0cea7af3401eb831d3ff12d0cf21623aL49-R50) [[3]](diffhunk://#diff-e3ed676ea26a4bbaef6080f871a0e82b0cea7af3401eb831d3ff12d0cf21623aL60-R61) [[4]](diffhunk://#diff-e3ed676ea26a4bbaef6080f871a0e82b0cea7af3401eb831d3ff12d0cf21623aL71-R72) [[5]](diffhunk://#diff-e3ed676ea26a4bbaef6080f871a0e82b0cea7af3401eb831d3ff12d0cf21623aL81-R90)
* Updated `scripts/mach_msg.js` to use `Process.getModuleByName` for retrieving the `mach_msg` export from `libSystem.B.dylib`.
* Updated `scripts/os_log.js` to use `Process.getModuleByName` for retrieving exports from `libsystem_trace.dylib`, replacing multiple calls to `Module.findExportByName`.

### Updated getGlobalExport API calls:

* Replaced `Module.getExportByName` with `Module.getGlobalExportByName` for global exports in `scripts/objc_msg.js` and `scripts/stalker.js`. [[1]](diffhunk://#diff-d95823bbc19786211d0e4121990eadfb0a8f4151ba5a4d8fce0f7f245720a9bbL6-R6) [[2]](diffhunk://#diff-8b1a4a58efcbd2347ce0fc73de3bdefa6f95ceeef367c09d519b2528ff2e9c38L3-R3)

### Cleanup:

* Removed redundant blank lines at the beginning of `scripts/os_log.js`.